### PR TITLE
Fix EnumAttr issues with Python 3

### DIFF
--- a/holster/enum.py
+++ b/holster/enum.py
@@ -33,6 +33,18 @@ class EnumAttr(object):
 
         return self.index > other
 
+    def __ge__(self, other):
+        if isinstance(other, EnumAttr):
+            return self.index >= other.index
+
+        return self.index >= other
+
+    def __le__(self, other):
+        if isinstance(other, EnumAttr):
+            return self.index <= other.index
+
+        return self.index <= other   
+
     def __repr__(self):
         return '<EnumAttr {}>'.format(self.name)
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -13,6 +13,10 @@ class EnumTestCase(TestCase):
         self.assertLess(enum.a, enum.b)
         self.assertGreater(enum.g, enum.a)
         self.assertGreater(enum.g, enum.f)
+        self.assertGreaterEqual(enum.b, enum.a)
+        self.assertGreaterEqual(enum.a, enum.a)
+        self.assertLessEqual(enum.a, enum.a)
+        self.assertLessEqual(enum.a, enum.b)
 
         self.assertEqual(enum.a.index, 1)
         self.assertEqual(enum.b.index, 2)


### PR DESCRIPTION
Using Disco's "command levels" feature on Python 3 fails spectacularly:

```py
  File "/home/ch/venvs/disco/lib/python3.6/site-packages/disco/bot/bot.py", line 355, in check_command_permissions
    if level >= command.level:
TypeError: '>=' not supported between instances of 'EnumAttr' and 'EnumAttr'
```

This patch adds the required magic methods that are needed for the enum comparisons to work on Python 3.

Confirmed working according to my tests.